### PR TITLE
py312

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,6 +304,7 @@ jobs:
         xvfb-run ${{ env.tool-exe }} nionui_app.test_ack | grep ACK
     - name: Test Conda Forge
       shell: bash -l {0}
+      if: matrix.python-version != '3.12'
       run: |
         # use conda versions instead of pypi versions. install before anything else.
         conda create -q -n test-env -c conda-forge python=${{ matrix.python-version }} numpy scipy h5py imageio setuptools -y
@@ -422,6 +423,7 @@ jobs:
         ${{ env.tool-exe }} nionui_app.test_ack | grep ACK
     - name: Test Conda Forge
       shell: bash -l {0}
+      if: matrix.python-version != '3.12'
       run: |
         # use conda versions instead of pypi versions. install before anything else.
         # use nomkl until anaconda gets its act together
@@ -523,6 +525,7 @@ jobs:
         ${{ env.tool-exe }} nionui_app.test_ack | grep ACK
     - name: Test Conda Forge
       shell: pwsh
+      if: matrix.python-version != '3.12'
       run: |
         # use conda versions instead of pypi versions. install before anything else.
         conda create -n test-env -c conda-forge -q python=${{ matrix.python-version }} numpy scipy h5py imageio setuptools -y

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        python-version: ["3.9", "3.10", "3.11"]
-        qt-version: ["6.5.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        qt-version: ["6.5.3"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -100,8 +100,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11.0]
-        python-version: ["3.9", "3.10", "3.11"]
-        qt-version: ["6.5.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        qt-version: ["6.5.3"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -161,8 +161,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019]
-        python-version: ["3.9", "3.10", "3.11"]
-        qt-version: ["6.5.2"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        qt-version: ["6.5.3"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -226,7 +226,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Download Wheel
@@ -332,7 +332,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-11.0]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Download Wheel
@@ -449,7 +449,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-2019]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v3
     - name: Download Wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
         auto-update-conda: true
         python-version: 3.11
     - name: Build Conda Package
+      if: matrix.python-version != '3.12'
       shell: bash -l {0}
       run: |
         python -c "import sys; print(sys.version)"
@@ -91,6 +92,7 @@ jobs:
         path: dist/*.whl
     - name: Upload Conda Package
       uses: actions/upload-artifact@v2
+      if: matrix.python-version != '3.12'
       with:
         name: ${{ env.tool-id }}-linux-conda-${{ matrix.python-version }}
         path: /usr/share/miniconda/envs/test/conda-bld/linux-64/*.tar.bz2
@@ -139,6 +141,7 @@ jobs:
         auto-update-conda: true
         python-version: 3.11
     - name: Build Conda Package
+      if: matrix.python-version != '3.12'
       shell: bash -l {0}
       run: |
         python -c "import sys; print(sys.version)"
@@ -152,6 +155,7 @@ jobs:
         path: dist/*.whl
     - name: Upload Conda Package
       uses: actions/upload-artifact@v2
+      if: matrix.python-version != '3.12'
       with:
         name: ${{ env.tool-id }}-macos-conda-${{ matrix.python-version }}
         path: /usr/local/miniconda/envs/test/conda-bld/osx-64/*.tar.bz2
@@ -203,6 +207,7 @@ jobs:
         auto-update-conda: true
         python-version: 3.11
     - name: Build Conda Package
+      if: matrix.python-version != '3.12'
       shell: pwsh
       run: |
         python -c "import sys; print(sys.version)"
@@ -216,6 +221,7 @@ jobs:
         path: dist\*.whl
     - name: Upload Conda Package
       uses: actions/upload-artifact@v2
+      if: matrix.python-version != '3.12'
       with:
         name: ${{ env.tool-id }}-win-conda-${{ matrix.python-version }}
         path: C:\Miniconda\envs\test\conda-bld\win-64\*.tar.bz2
@@ -238,6 +244,7 @@ jobs:
     - name: Download Conda
       uses: actions/download-artifact@v2
       id: download_conda
+      if: matrix.python-version != '3.12'
       with:
         name: ${{ env.tool-id }}-linux-conda-${{ matrix.python-version }}
         path: conda_downloads
@@ -281,6 +288,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Test Conda
       shell: bash -l {0}
+      if: matrix.python-version != '3.12'
       run: |
         # use conda versions instead of pypi versions. install before anything else.
         conda update --all -q -y
@@ -319,7 +327,7 @@ jobs:
         packages_dir: ${{steps.download_wheel.outputs.download-path}}
         password: ${{ secrets.PYPI_PASSWORD }}
     - name: Build/publish anaconda package
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && matrix.os == 'ubuntu-20.04'
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && matrix.os == 'ubuntu-20.04' && matrix.python-version != '3.12'
       shell: bash -l {0}
       run: |
         conda info
@@ -344,6 +352,7 @@ jobs:
     - name: Download Conda
       uses: actions/download-artifact@v2
       id: download_conda
+      if: matrix.python-version != '3.12'
       with:
         name: ${{ env.tool-id }}-macos-conda-${{ matrix.python-version }}
         path: conda_downloads
@@ -397,6 +406,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Test Conda
       shell: bash -l {0}
+      if: matrix.python-version != '3.12'
       run: |
         # use conda versions instead of pypi versions. install before anything else.
         # use nomkl until anaconda gets its act together
@@ -436,7 +446,7 @@ jobs:
         packages_dir: ${{steps.download_wheel.outputs.download-path}}
         password: ${{ secrets.PYPI_PASSWORD }}
     - name: Build/publish anaconda package
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && matrix.os == 'macos-11.0'
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && matrix.os == 'macos-11.0' && matrix.python-version != '3.12'
       shell: bash -l {0}
       run: |
         conda info
@@ -461,6 +471,7 @@ jobs:
     - name: Download Conda
       uses: actions/download-artifact@v2
       id: download_conda
+      if: matrix.python-version != '3.12'
       with:
         name: ${{ env.tool-id }}-win-conda-${{ matrix.python-version }}
         path: conda_downloads
@@ -495,6 +506,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Test Conda
       shell: pwsh
+      if: matrix.python-version != '3.12'
       run: |
         # use conda versions instead of pypi versions. install before anything else.
         conda update -q --all -y
@@ -535,7 +547,7 @@ jobs:
         packages_dir: ${{steps.download_wheel.outputs.download-path}}
         password: ${{ secrets.PYPI_PASSWORD }}
     - name: Build/publish anaconda package
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && matrix.os == 'windows-2019'
+      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') && matrix.os == 'windows-2019' && matrix.python-version != '3.12'
       shell: pwsh
       run: |
         conda info

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install install wheel
         python -m pip install install packaging
-        python -m pip install install "numpy>=1.23,<1.24"
+        python -m pip install install "numpy>=1.26,<1.27"
         pushd launcher
         PYTHON=`python -c "import sys; print(sys.executable, end='')"`
         cmake CMakeLists.txt -DPython3_EXECUTABLE="$PYTHON"
@@ -76,14 +76,14 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        python-version: 3.9
+        python-version: 3.11
     - name: Build Conda Package
       shell: bash -l {0}
       run: |
         python -c "import sys; print(sys.version)"
         python -c "import sys; print(sys.executable)"
-        conda install conda-build -y
-        conda build --quiet --python ${{ matrix.python-version }} ./.github/workflows/recipe
+        conda install -q conda-build -y
+        conda build -q --python ${{ matrix.python-version }} ./.github/workflows/recipe
     - name: Upload Wheel
       uses: actions/upload-artifact@v2
       with:
@@ -124,7 +124,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install install packaging
-        python -m pip install install "numpy>=1.23,<1.24"
+        python -m pip install install "numpy>=1.26,<1.27"
         pushd launcher
         PYTHON=`python -c "import sys; print(sys.executable, end='')"`
         cmake CMakeLists.txt -DPython3_EXECUTABLE="$PYTHON"
@@ -137,14 +137,14 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        python-version: 3.9
+        python-version: 3.11
     - name: Build Conda Package
       shell: bash -l {0}
       run: |
         python -c "import sys; print(sys.version)"
         python -c "import sys; print(sys.executable)"
-        conda install conda-build -y
-        conda build --quiet --python ${{ matrix.python-version }} ./.github/workflows/recipe
+        conda install -q conda-build -y
+        conda build -q --python ${{ matrix.python-version }} ./.github/workflows/recipe
     - name: Upload Wheel
       uses: actions/upload-artifact@v2
       with:
@@ -186,7 +186,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install packaging
-        pip install "numpy>=1.23,<1.24"
+        pip install "numpy>=1.26,<1.27"
         pushd launcher
         $PYTHON_EXEC = python -c "import sys; print(sys.executable, end='')"
         cmake CMakeLists.txt -DPython3_EXECUTABLE="$PYTHON_EXEC"
@@ -201,14 +201,14 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        python-version: 3.9
+        python-version: 3.11
     - name: Build Conda Package
       shell: pwsh
       run: |
         python -c "import sys; print(sys.version)"
         python -c "import sys; print(sys.executable)"
-        conda install conda-build -y
-        conda build --quiet --python ${{ matrix.python-version }} ./.github/workflows/recipe
+        conda install -q conda-build -y
+        conda build -q --python ${{ matrix.python-version }} ./.github/workflows/recipe
     - name: Upload Wheel
       uses: actions/upload-artifact@v2
       with:
@@ -283,10 +283,10 @@ jobs:
       shell: bash -l {0}
       run: |
         # use conda versions instead of pypi versions. install before anything else.
-        conda update --all -y
-        conda install numpy scipy h5py imageio setuptools pip -y
-        conda install -y -c nion ${{ env.tool-package }}
-        conda install -y ${{steps.download_conda.outputs.download-path}}/*.tar.bz2
+        conda update --all -q -y
+        conda install -q numpy scipy h5py imageio setuptools pip -y
+        conda install -q -y -c nion ${{ env.tool-package }}
+        conda install -q -y ${{steps.download_conda.outputs.download-path}}/*.tar.bz2
         pushd nionui_app_test
         python -m pip install .
         popd
@@ -298,10 +298,10 @@ jobs:
       shell: bash -l {0}
       run: |
         # use conda versions instead of pypi versions. install before anything else.
-        conda create -n test-env -c conda-forge python=${{ matrix.python-version }} numpy scipy h5py imageio setuptools -y
+        conda create -q -n test-env -c conda-forge python=${{ matrix.python-version }} numpy scipy h5py imageio setuptools -y
         conda activate test-env
-        conda install -y -c nion -c conda-forge ${{ env.tool-package }}
-        conda install -y -c conda-forge ${{steps.download_conda.outputs.download-path}}/*.tar.bz2
+        conda install -q -y -c nion -c conda-forge ${{ env.tool-package }}
+        conda install -q -y -c conda-forge ${{steps.download_conda.outputs.download-path}}/*.tar.bz2
         pushd nionui_app_test
         python -m pip install .
         popd
@@ -400,9 +400,9 @@ jobs:
       run: |
         # use conda versions instead of pypi versions. install before anything else.
         # use nomkl until anaconda gets its act together
-        conda install nomkl numpy scipy h5py imageio setuptools -y
-        conda install -y -c nion ${{ env.tool-package }}
-        conda install -y ${{steps.download_conda.outputs.download-path}}/*.tar.bz2
+        conda install -q nomkl numpy scipy h5py imageio setuptools -y
+        conda install -q -y -c nion ${{ env.tool-package }}
+        conda install -q -y ${{steps.download_conda.outputs.download-path}}/*.tar.bz2
         pushd nionui_app_test
         python -m pip install .
         popd
@@ -415,10 +415,10 @@ jobs:
       run: |
         # use conda versions instead of pypi versions. install before anything else.
         # use nomkl until anaconda gets its act together
-        conda create -n test-env -c conda-forge python=${{ matrix.python-version }} numpy scipy h5py imageio setuptools -y
+        conda create -n test-env -c conda-forge -q python=${{ matrix.python-version }} numpy scipy h5py imageio setuptools -y
         conda activate test-env
-        conda install -y -c nion -c conda-forge ${{ env.tool-package }}
-        conda install -y -c conda-forge ${{steps.download_conda.outputs.download-path}}/*.tar.bz2
+        conda install -q -y -c nion -c conda-forge ${{ env.tool-package }}
+        conda install -q -y -c conda-forge ${{steps.download_conda.outputs.download-path}}/*.tar.bz2
         pushd nionui_app_test
         python -m pip install .
         popd
@@ -440,7 +440,7 @@ jobs:
       shell: bash -l {0}
       run: |
         conda info
-        conda install anaconda-client -y
+        conda install -q anaconda-client -y
         anaconda --token ${{ secrets.anaconda_token }} upload --user nion --skip-existing ${{steps.download_conda.outputs.download-path}}/*.tar.bz2
   test_win:
     needs: build_win
@@ -497,11 +497,11 @@ jobs:
       shell: pwsh
       run: |
         # use conda versions instead of pypi versions. install before anything else.
-        conda update --all -y
-        conda install numpy scipy h5py imageio setuptools -y
-        conda install -y -c nion ${{ env.tool-package }}
+        conda update -q --all -y
+        conda install -q numpy scipy h5py imageio setuptools -y
+        conda install -q -y -c nion ${{ env.tool-package }}
         $filename = Get-ChildItem -name ${{steps.download_conda.outputs.download-path}}\*.tar.bz2
-        conda install -y ${{steps.download_conda.outputs.download-path}}\$filename
+        conda install -q -y ${{steps.download_conda.outputs.download-path}}\$filename
         pushd nionui_app_test
         python -m pip install .
         popd
@@ -513,11 +513,11 @@ jobs:
       shell: pwsh
       run: |
         # use conda versions instead of pypi versions. install before anything else.
-        conda create -n test-env -c conda-forge python=${{ matrix.python-version }} numpy scipy h5py imageio setuptools -y
+        conda create -n test-env -c conda-forge -q python=${{ matrix.python-version }} numpy scipy h5py imageio setuptools -y
         conda activate test-env
-        conda install -y -c nion -c conda-forge ${{ env.tool-package }}
+        conda install -q -y -c nion -c conda-forge ${{ env.tool-package }}
         $filename = Get-ChildItem -name ${{steps.download_conda.outputs.download-path}}\*.tar.bz2
-        conda install -y -c conda-forge ${{steps.download_conda.outputs.download-path}}\$filename
+        conda install -q -y -c conda-forge ${{steps.download_conda.outputs.download-path}}\$filename
         pushd nionui_app_test
         python -m pip install .
         popd
@@ -539,7 +539,7 @@ jobs:
       shell: pwsh
       run: |
         conda info
-        conda install anaconda-client -y
+        conda install -q anaconda-client -y
         $filename = Get-ChildItem -name ${{steps.download_conda.outputs.download-path}}\*.tar.bz2
         Write-Output ${{steps.download_conda.outputs.download-path}}\$filename
         anaconda --token ${{ secrets.anaconda_token }} upload --user nion --skip-existing ${{steps.download_conda.outputs.download-path}}\$filename

--- a/.github/workflows/recipe/meta.yaml
+++ b/.github/workflows/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - numpy 1.24.*
+    - numpy 1.26.*
   run:
     - python
     - setuptools

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -419,7 +419,11 @@ QList<T> reversed( const QList<T> & in ) {
     return result;
 }
 
-#define Py_UNICODE_to_QString(x) QString::fromWCharArray(x)
+QString PyObjectToQString(PyObject *o)
+{
+    PythonWChar ws(o);
+    return (ws.s() != nullptr) ? QString::fromWCharArray(ws.s(), ws.size()) : QString();
+}
 
 //----
 
@@ -458,10 +462,10 @@ static PyObject *Action_create(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *title_u = NULL;
+    PyObject *title_u = NULL;
     char *key_sequence_c = NULL;
     char *role_c = NULL;
-    if (!PythonSupport::instance()->parse()(args, "Ouzz", &obj0, &title_u, &key_sequence_c, &role_c))
+    if (!PythonSupport::instance()->parse()(args, "OOzz", &obj0, &title_u, &key_sequence_c, &role_c))
         return NULL;
 
     DocumentWindow *document_window = Unwrap<DocumentWindow>(obj0);
@@ -469,7 +473,7 @@ static PyObject *Action_create(PyObject * /*self*/, PyObject *args)
         return NULL;
 
     PyAction *action = new PyAction(document_window);
-    action->setText(Py_UNICODE_to_QString(title_u));
+    action->setText(PyObjectToQString(title_u));
 
     if (key_sequence_c)
     {
@@ -631,15 +635,15 @@ static PyObject *Action_setTitle(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *title_u = NULL;
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &title_u))
+    PyObject *title_u = NULL;
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &title_u))
         return NULL;
 
     QAction *action = Unwrap<QAction>(obj0);
     if (action == NULL)
         return NULL;
 
-    action->setText(Py_UNICODE_to_QString(title_u));
+    action->setText(PyObjectToQString(title_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -1193,16 +1197,16 @@ static PyObject *CheckBox_setText(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyCheckBox *check_box = Unwrap<PyCheckBox>(obj0);
     if (check_box == NULL)
         return NULL;
 
-    check_box->setText(Py_UNICODE_to_QString(text_u));
+    check_box->setText(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -1268,14 +1272,14 @@ static PyObject *Clipboard_setText(PyObject * /*self*/, PyObject *args)
         return NULL;
     }
 
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "u", &text_u))
+    if (!PythonSupport::instance()->parse()(args, "O", &text_u))
         return NULL;
 
     QClipboard *clipboard = QApplication::clipboard();
 
-    clipboard->setText(Py_UNICODE_to_QString(text_u));
+    clipboard->setText(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -1304,16 +1308,16 @@ static PyObject *ComboBox_addItem(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyComboBox *combobox = Unwrap<PyComboBox>(obj0);
     if (combobox == NULL)
         return NULL;
 
-    combobox->addItem(Py_UNICODE_to_QString(text_u));
+    combobox->addItem(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -1397,16 +1401,16 @@ static PyObject *ComboBox_setCurrentText(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
-    return NULL;
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
+        return NULL;
 
     PyComboBox *combobox = Unwrap<PyComboBox>(obj0);
     if (combobox == NULL)
     return NULL;
 
-    combobox->setCurrentText(Py_UNICODE_to_QString(text_u));
+    combobox->setCurrentText(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -1569,11 +1573,11 @@ static PyObject *Core_getLocation(PyObject * /*self*/, PyObject *args)
 
 static PyObject *Core_out(PyObject * /*self*/, PyObject *args)
 {
-    Py_UNICODE *output_u = NULL;
-    if (!PythonSupport::instance()->parse()(args, "u", &output_u))
+    PyObject *output_u = NULL;
+    if (!PythonSupport::instance()->parse()(args, "O", &output_u))
         return NULL;
 
-    QString output = Py_UNICODE_to_QString(output_u);
+    QString output = PyObjectToQString(output_u);
 
     {
         Python_ThreadAllow thread_allow;
@@ -1594,11 +1598,11 @@ static PyObject *Core_out(PyObject * /*self*/, PyObject *args)
 
 static PyObject *Core_pathToURL(PyObject * /*self*/, PyObject *args)
 {
-    Py_UNICODE *path_u = NULL;
-    if (!PythonSupport::instance()->parse()(args, "u", &path_u))
+    PyObject *path_u = NULL;
+    if (!PythonSupport::instance()->parse()(args, "O", &path_u))
         return NULL;
 
-    QUrl url = QUrl::fromLocalFile(Py_UNICODE_to_QString(path_u));
+    QUrl url = QUrl::fromLocalFile(PyObjectToQString(path_u));
     QString url_string = url.toString();
 
     return PythonSupport::instance()->build()("s", url_string.toUtf8().data());
@@ -1606,12 +1610,12 @@ static PyObject *Core_pathToURL(PyObject * /*self*/, PyObject *args)
 
 static PyObject *Core_readImageToBinary(PyObject * /*self*/, PyObject *args)
 {
-    Py_UNICODE *filename_u = NULL;
-    if (!PythonSupport::instance()->parse()(args, "u", &filename_u))
+    PyObject *filename_u = NULL;
+    if (!PythonSupport::instance()->parse()(args, "O", &filename_u))
         return NULL;
 
     // Read the image
-    QImageReader reader(Py_UNICODE_to_QString(filename_u));
+    QImageReader reader(PyObjectToQString(filename_u));
     if (reader.canRead())
     {
         Python_ThreadAllow thread_allow;
@@ -1632,15 +1636,15 @@ static PyObject *Core_readImageToBinary(PyObject * /*self*/, PyObject *args)
 
 static PyObject *Core_setApplicationInfo(PyObject * /*self*/, PyObject *args)
 {
-    Py_UNICODE *application_name_u = NULL;
-    Py_UNICODE *organization_name_u = NULL;
-    Py_UNICODE *organization_domain_u = NULL;
-    if (!PythonSupport::instance()->parse()(args, "uuu", &application_name_u, &organization_name_u, &organization_domain_u))
+    PyObject *application_name_u = NULL;
+    PyObject *organization_name_u = NULL;
+    PyObject *organization_domain_u = NULL;
+    if (!PythonSupport::instance()->parse()(args, "OOO", &application_name_u, &organization_name_u, &organization_domain_u))
         return NULL;
 
-    QApplication::setApplicationName(Py_UNICODE_to_QString(application_name_u));
-    QApplication::setOrganizationName(Py_UNICODE_to_QString(organization_name_u));
-    QApplication::setOrganizationDomain(Py_UNICODE_to_QString(organization_domain_u));
+    QApplication::setApplicationName(PyObjectToQString(application_name_u));
+    QApplication::setOrganizationName(PyObjectToQString(organization_name_u));
+    QApplication::setOrganizationDomain(PyObjectToQString(organization_domain_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -1699,9 +1703,9 @@ static PyObject *Core_writeBinaryToImage(PyObject * /*self*/, PyObject *args)
     int w = 0;
     int h = 0;
     PyObject *obj0 = NULL;
-    Py_UNICODE *filename_u = NULL;
+    PyObject *filename_u = NULL;
     char *format_c = NULL;
-    if (!PythonSupport::instance()->parse()(args, "iiOus", &w, &h, &obj0, &filename_u, &format_c))
+    if (!PythonSupport::instance()->parse()(args, "iiOOs", &w, &h, &obj0, &filename_u, &format_c))
         return NULL;
 
     QImageInterface image;
@@ -1711,7 +1715,7 @@ static PyObject *Core_writeBinaryToImage(PyObject * /*self*/, PyObject *args)
         return NULL;
 
     // Write the image
-    QImageWriter writer(Py_UNICODE_to_QString(filename_u), format_c);
+    QImageWriter writer(PyObjectToQString(filename_u), format_c);
 
     if (writer.canWrite())
         writer.write(image.image);
@@ -1795,10 +1799,10 @@ static PyObject *DocumentWindow_addDockWidget(PyObject * /*self*/, PyObject *arg
     PyObject *obj0 = NULL;
     PyObject *obj1 = NULL;
     char *identifier_c = NULL;
-    Py_UNICODE *title_u = NULL;
+    PyObject *title_u = NULL;
     PyObject *obj2 = NULL;
     char *position_c = NULL;
-    if (!PythonSupport::instance()->parse()(args, "OOsuOs", &obj0, &obj1, &identifier_c, &title_u, &obj2, &position_c))
+    if (!PythonSupport::instance()->parse()(args, "OOsOOs", &obj0, &obj1, &identifier_c, &title_u, &obj2, &position_c))
         return NULL;
 
     // Grab the document window
@@ -1829,7 +1833,7 @@ static PyObject *DocumentWindow_addDockWidget(PyObject * /*self*/, PyObject *arg
         allowed_positions_mask |= mapping[allowed_position];
     }
 
-    DockWidget *dock_widget = new DockWidget(Py_UNICODE_to_QString(title_u));
+    DockWidget *dock_widget = new DockWidget(PyObjectToQString(title_u));
     dock_widget->setAllowedAreas(allowed_positions_mask);
     dock_widget->setWidget(widget);
     dock_widget->setObjectName(identifier_c);
@@ -1847,8 +1851,8 @@ static PyObject *DocumentWindow_addMenu(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *title_u = NULL;
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &title_u))
+    PyObject *title_u = NULL;
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &title_u))
         return NULL;
 
     DocumentWindow *document_window = Unwrap<DocumentWindow>(obj0);
@@ -1856,7 +1860,7 @@ static PyObject *DocumentWindow_addMenu(PyObject * /*self*/, PyObject *args)
         return NULL;
 
     PyMenu *menu = new PyMenu();
-    menu->setTitle(Py_UNICODE_to_QString(title_u));
+    menu->setTitle(PyObjectToQString(title_u));
 
     document_window->menuBar()->addMenu(menu);
 
@@ -1920,13 +1924,13 @@ static PyObject *DocumentWindow_create(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *parent_window_obj = NULL;
-    Py_UNICODE *title_u = NULL;
-    if (!PythonSupport::instance()->parse()(args, "OZ", &parent_window_obj, &title_u))
+    PyObject *title_u = NULL;
+    if (!PythonSupport::instance()->parse()(args, "OO", &parent_window_obj, &title_u))
         return NULL;
 
     DocumentWindow *parent_window = Unwrap<DocumentWindow>(parent_window_obj);
 
-    QString title = title_u ? Py_UNICODE_to_QString(title_u) : QString();
+    QString title = title_u ? PyObjectToQString(title_u) : QString();
 
     DocumentWindow *document_window = new DocumentWindow(title, parent_window);
 
@@ -2012,24 +2016,24 @@ static PyObject *DocumentWindow_getFilePath(PyObject * /*self*/, PyObject *args)
     }
     PyObject *obj0 = NULL;
     char *mode_c = NULL;
-    Py_UNICODE *caption_u = NULL;
-    Py_UNICODE *dir_u = NULL;
-    Py_UNICODE *filter_u = NULL;
-    Py_UNICODE *selected_filter_u = NULL;
-    if (!PythonSupport::instance()->parse()(args, "Osuuuu", &obj0, &mode_c, &caption_u, &dir_u, &filter_u, &selected_filter_u))
+    PyObject *caption_u = NULL;
+    PyObject *dir_u = NULL;
+    PyObject *filter_u = NULL;
+    PyObject *selected_filter_u = NULL;
+    if (!PythonSupport::instance()->parse()(args, "OsOOOO", &obj0, &mode_c, &caption_u, &dir_u, &filter_u, &selected_filter_u))
         return NULL;
 
     DocumentWindow *document_window = PythonSupport::instance()->isNone(obj0) ? NULL : Unwrap<DocumentWindow>(obj0);
 
     if (strcmp(mode_c, "save")==0)
     {
-		QString selected_filter = Py_UNICODE_to_QString(selected_filter_u);
+		QString selected_filter = PyObjectToQString(selected_filter_u);
         QDir selected_dir;
 
         QString ret;
         {
             Python_ThreadAllow thread_allow;
-            ret = GetSaveFileName(document_window, Py_UNICODE_to_QString(caption_u), Py_UNICODE_to_QString(dir_u), Py_UNICODE_to_QString(filter_u), &selected_filter, &selected_dir);
+            ret = GetSaveFileName(document_window, PyObjectToQString(caption_u), PyObjectToQString(dir_u), PyObjectToQString(filter_u), &selected_filter, &selected_dir);
         }
         QVariantList result;
         result << ret;
@@ -2040,13 +2044,13 @@ static PyObject *DocumentWindow_getFilePath(PyObject * /*self*/, PyObject *args)
     }
     else if (strcmp(mode_c, "load")==0)
     {
-		QString selected_filter = Py_UNICODE_to_QString(selected_filter_u);
+		QString selected_filter = PyObjectToQString(selected_filter_u);
         QDir selected_dir;
 
         QString ret;
         {
             Python_ThreadAllow thread_allow;
-            ret = GetOpenFileName(document_window, Py_UNICODE_to_QString(caption_u), Py_UNICODE_to_QString(dir_u), Py_UNICODE_to_QString(filter_u), &selected_filter, &selected_dir);
+            ret = GetOpenFileName(document_window, PyObjectToQString(caption_u), PyObjectToQString(dir_u), PyObjectToQString(filter_u), &selected_filter, &selected_dir);
         }
 
         QVariantList result;
@@ -2059,11 +2063,11 @@ static PyObject *DocumentWindow_getFilePath(PyObject * /*self*/, PyObject *args)
     else if (strcmp(mode_c, "directory") == 0)
     {
         QDir selected_dir;
-        QDir::setCurrent(Py_UNICODE_to_QString(dir_u));
+        QDir::setCurrent(PyObjectToQString(dir_u));
         QString directory;
         {
             Python_ThreadAllow thread_allow;
-            directory = GetExistingDirectory(document_window, Py_UNICODE_to_QString(caption_u), Py_UNICODE_to_QString(dir_u), &selected_dir);
+            directory = GetExistingDirectory(document_window, PyObjectToQString(caption_u), PyObjectToQString(dir_u), &selected_dir);
         }
 
         QVariantList result;
@@ -2075,13 +2079,13 @@ static PyObject *DocumentWindow_getFilePath(PyObject * /*self*/, PyObject *args)
     }
     else if (strcmp(mode_c, "loadmany") == 0)
     {
-		QString selected_filter = Py_UNICODE_to_QString(selected_filter_u);
+		QString selected_filter = PyObjectToQString(selected_filter_u);
         QDir selected_dir;
 
         QStringList file_names;
         {
             Python_ThreadAllow thread_allow;
-            file_names = GetOpenFileNames(document_window, Py_UNICODE_to_QString(caption_u), Py_UNICODE_to_QString(dir_u), Py_UNICODE_to_QString(filter_u), &selected_filter, &selected_dir);
+            file_names = GetOpenFileNames(document_window, PyObjectToQString(caption_u), PyObjectToQString(dir_u), PyObjectToQString(filter_u), &selected_filter, &selected_dir);
         }
 
         QVariantList result;
@@ -2149,9 +2153,9 @@ static PyObject *DocumentWindow_insertMenu(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *title_u = NULL;
+    PyObject *title_u = NULL;
     PyObject *obj1 = NULL;
-    if (!PythonSupport::instance()->parse()(args, "OuO", &obj0, &title_u, &obj1))
+    if (!PythonSupport::instance()->parse()(args, "OOO", &obj0, &title_u, &obj1))
         return NULL;
 
     DocumentWindow *document_window = Unwrap<DocumentWindow>(obj0);
@@ -2163,7 +2167,7 @@ static PyObject *DocumentWindow_insertMenu(PyObject * /*self*/, PyObject *args)
         return NULL;
 
     PyMenu *menu = new PyMenu();
-    menu->setTitle(Py_UNICODE_to_QString(title_u));
+    menu->setTitle(PyObjectToQString(title_u));
 
     document_window->menuBar()->insertMenu(before_menu->menuAction(), menu);
 
@@ -2335,8 +2339,8 @@ static PyObject *DocumentWindow_setTitle(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *title_u = NULL;
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &title_u))
+    PyObject *title_u = NULL;
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &title_u))
         return NULL;
 
     // Grab the document window
@@ -2344,7 +2348,7 @@ static PyObject *DocumentWindow_setTitle(PyObject * /*self*/, PyObject *args)
     if (document_window == NULL)
         return NULL;
 
-    document_window->setWindowTitle(Py_UNICODE_to_QString(title_u));
+    document_window->setWindowTitle(PyObjectToQString(title_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -2358,8 +2362,8 @@ static PyObject *DocumentWindow_setWindowFilePath(PyObject * /*self*/, PyObject 
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *title_u = NULL;
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &title_u))
+    PyObject *title_u = NULL;
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &title_u))
         return NULL;
 
     // Grab the document window
@@ -2367,7 +2371,7 @@ static PyObject *DocumentWindow_setWindowFilePath(PyObject * /*self*/, PyObject 
     if (document_window == NULL)
         return NULL;
 
-    document_window->setWindowFilePath(Py_UNICODE_to_QString(title_u));
+    document_window->setWindowFilePath(PyObjectToQString(title_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -2736,8 +2740,8 @@ static PyObject *GroupBoxWidget_setTitle(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *title_u = NULL;
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &title_u))
+    PyObject *title_u = NULL;
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &title_u))
         return NULL;
 
     // Grab the document window
@@ -2745,7 +2749,7 @@ static PyObject *GroupBoxWidget_setTitle(PyObject * /*self*/, PyObject *args)
     if (group_box == NULL)
         return NULL;
 
-    group_box->setTitle(Py_UNICODE_to_QString(title_u));
+    group_box->setTitle(PyObjectToQString(title_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -2938,16 +2942,16 @@ static PyObject *Label_setText(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     QLabel *label = Unwrap<QLabel>(obj0);
     if (label == NULL)
         return NULL;
 
-    QString text = Py_UNICODE_to_QString(text_u);
+    QString text = PyObjectToQString(text_u);
     if (text.length() > 0)
         label->setText(text);
     else
@@ -3216,16 +3220,16 @@ static PyObject *LineEdit_setPlaceholderText(PyObject * /*self*/, PyObject *args
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyLineEdit *line_edit = Unwrap<PyLineEdit>(obj0);
     if (line_edit == NULL)
         return NULL;
 
-    line_edit->setPlaceholderText(Py_UNICODE_to_QString(text_u));
+    line_edit->setPlaceholderText(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -3239,16 +3243,16 @@ static PyObject *LineEdit_setText(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyLineEdit *line_edit = Unwrap<PyLineEdit>(obj0);
     if (line_edit == NULL)
         return NULL;
 
-    line_edit->setText(Py_UNICODE_to_QString(text_u));
+    line_edit->setText(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -3288,9 +3292,9 @@ static PyObject *Menu_addMenu(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *title_u = NULL;
+    PyObject *title_u = NULL;
     PyObject *obj1 = NULL;
-    if (!PythonSupport::instance()->parse()(args, "OuO", &obj0, &title_u, &obj1))
+    if (!PythonSupport::instance()->parse()(args, "OOO", &obj0, &title_u, &obj1))
         return NULL;
 
     PyMenu *menu = Unwrap<PyMenu>(obj0);
@@ -3301,7 +3305,7 @@ static PyObject *Menu_addMenu(PyObject * /*self*/, PyObject *args)
     if (sub_menu == NULL)
         return NULL;
 
-    sub_menu->setTitle(Py_UNICODE_to_QString(title_u));
+    sub_menu->setTitle(PyObjectToQString(title_u));
 
     menu->addMenu(sub_menu);
 
@@ -3631,16 +3635,16 @@ static PyObject *PushButton_setText(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyPushButton *push_button = Unwrap<PyPushButton>(obj0);
     if (push_button == NULL)
         return NULL;
 
-    push_button->setText(Py_UNICODE_to_QString(text_u));
+    push_button->setText(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -3762,16 +3766,16 @@ static PyObject *RadioButton_setText(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyRadioButton *radio_button = Unwrap<PyRadioButton>(obj0);
     if (radio_button == NULL)
         return NULL;
 
-    radio_button->setText(Py_UNICODE_to_QString(text_u));
+    radio_button->setText(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -4303,8 +4307,8 @@ static PyObject *TabWidget_addTab(PyObject * /*self*/, PyObject *args)
 
     PyObject *obj0 = NULL;
     PyObject *obj1 = NULL;
-    Py_UNICODE *label_u = NULL;
-    if (!PythonSupport::instance()->parse()(args, "OOu", &obj0, &obj1, &label_u))
+    PyObject *label_u = NULL;
+    if (!PythonSupport::instance()->parse()(args, "OOO", &obj0, &obj1, &label_u))
         return NULL;
 
     // Grab the container (tab widget)
@@ -4317,7 +4321,7 @@ static PyObject *TabWidget_addTab(PyObject * /*self*/, PyObject *args)
     if (widget == NULL)
         return NULL;
 
-    container->addTab(widget, Py_UNICODE_to_QString(label_u));
+    container->addTab(widget, PyObjectToQString(label_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -4398,16 +4402,16 @@ static PyObject *TextBrowser_scrollToAnchor(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *anchor_u = NULL;
+    PyObject *anchor_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &anchor_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &anchor_u))
         return NULL;
 
     PyTextBrowser *text_browser = Unwrap<PyTextBrowser>(obj0);
     if (text_browser == NULL)
         return NULL;
 
-    text_browser->scrollToAnchor(Py_UNICODE_to_QString(anchor_u));
+    text_browser->scrollToAnchor(PyObjectToQString(anchor_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -4421,16 +4425,16 @@ static PyObject *TextBrowser_setHtml(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyTextBrowser *text_browser = Unwrap<PyTextBrowser>(obj0);
     if (text_browser == NULL)
         return NULL;
 
-    text_browser->setHtml(Py_UNICODE_to_QString(text_u));
+    text_browser->setHtml(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -4444,16 +4448,16 @@ static PyObject *TextBrowser_setMarkdown(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyTextBrowser *text_browser = Unwrap<PyTextBrowser>(obj0);
     if (text_browser == NULL)
         return NULL;
 
-    text_browser->setMarkdown(Py_UNICODE_to_QString(text_u));
+    text_browser->setMarkdown(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -4467,16 +4471,16 @@ static PyObject *TextBrowser_setText(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyTextBrowser *text_browser = Unwrap<PyTextBrowser>(obj0);
     if (text_browser == NULL)
         return NULL;
 
-    text_browser->setText(Py_UNICODE_to_QString(text_u));
+    text_browser->setText(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -4565,16 +4569,16 @@ static PyObject *TextEdit_appendText(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyTextEdit *text_edit = Unwrap<PyTextEdit>(obj0);
     if (text_edit == NULL)
         return NULL;
 
-    text_edit->append(Py_UNICODE_to_QString(text_u));
+    text_edit->append(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -4753,16 +4757,16 @@ static PyObject *TextEdit_insertText(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyTextEdit *text_edit = Unwrap<PyTextEdit>(obj0);
     if (text_edit == NULL)
         return NULL;
 
-    text_edit->insertPlainText(Py_UNICODE_to_QString(text_u));
+    text_edit->insertPlainText(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -4911,9 +4915,9 @@ static PyObject *TextEdit_setPlaceholderText(PyObject * /*self*/, PyObject *args
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyTextEdit *text_edit = Unwrap<PyTextEdit>(obj0);
@@ -4921,7 +4925,7 @@ static PyObject *TextEdit_setPlaceholderText(PyObject * /*self*/, PyObject *args
         return NULL;
 
 #if !defined(Q_OS_LINUX)
-    text_edit->setPlaceholderText(Py_UNICODE_to_QString(text_u));
+    text_edit->setPlaceholderText(PyObjectToQString(text_u));
 #endif
 
     return PythonSupport::instance()->getNoneReturnValue();
@@ -4961,16 +4965,16 @@ static PyObject *TextEdit_setText(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *text_u = NULL;
+    PyObject *text_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &text_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &text_u))
         return NULL;
 
     PyTextEdit *text_edit = Unwrap<PyTextEdit>(obj0);
     if (text_edit == NULL)
         return NULL;
 
-    text_edit->setText(Py_UNICODE_to_QString(text_u));
+    text_edit->setText(PyObjectToQString(text_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }
@@ -6049,16 +6053,16 @@ static PyObject *Widget_setToolTip(PyObject * /*self*/, PyObject *args)
     }
 
     PyObject *obj0 = NULL;
-    Py_UNICODE *tool_tip_u = NULL;
+    PyObject *tool_tip_u = NULL;
 
-    if (!PythonSupport::instance()->parse()(args, "Ou", &obj0, &tool_tip_u))
+    if (!PythonSupport::instance()->parse()(args, "OO", &obj0, &tool_tip_u))
         return NULL;
 
     QWidget *widget = Unwrap<QWidget>(obj0);
     if (widget == NULL)
         return NULL;
 
-    widget->setToolTip(Py_UNICODE_to_QString(tool_tip_u));
+    widget->setToolTip(PyObjectToQString(tool_tip_u));
 
     return PythonSupport::instance()->getNoneReturnValue();
 }

--- a/launcher/PythonStubs.cpp
+++ b/launcher/PythonStubs.cpp
@@ -89,6 +89,8 @@ typedef int (*PyType_IsSubtypeFn)(PyTypeObject *a, PyTypeObject *b);
 typedef char* (*PyUnicode_AsUTF8Fn)(PyObject *unicode);
 typedef PyObject* (*PyUnicode_DecodeUTF16Fn)(const char *s, Py_ssize_t size, const char *errors, int *byteorder);
 typedef PyObject *(*PyUnicode_FromStringFn)(const char *u);
+typedef wchar_t *(*PyUnicode_AsWideCharStringFn)(PyObject *unicode, Py_ssize_t *size);
+typedef void (*PyMem_FreeFn)(void *p);
 typedef PyObject* (*Py_CompileStringExFlagsFn)(const char *str, const char *filename, int start, PyCompilerFlags *flags, int optimize);
 typedef void (*Py_InitializeFn)();
 typedef void (*Py_FinalizeFn)();
@@ -158,6 +160,8 @@ static PyType_IsSubtypeFn fType_IsSubtype = 0;
 static PyUnicode_AsUTF8Fn fUnicode_AsUTF8 = 0;
 static PyUnicode_DecodeUTF16Fn fUnicode_DecodeUTF16 = 0;
 static PyUnicode_FromStringFn fUnicode_FromString = 0;
+static PyUnicode_AsWideCharStringFn fUnicode_AsWideCharString = 0;
+static PyMem_FreeFn fMem_Free = 0;
 static Py_CompileStringExFlagsFn fCompileStringExFlags = 0;
 static Py_InitializeFn fInitialize = 0;
 static Py_FinalizeFn fFinalize = 0;
@@ -733,6 +737,20 @@ PyObject* DPyUnicode_FromString(const char *u)
     if (fUnicode_FromString == 0)
         fUnicode_FromString = (PyUnicode_FromStringFn)LOOKUP_SYMBOL(pylib, "PyUnicode_FromString");
     return fUnicode_FromString(u);
+}
+
+wchar_t *DPyUnicode_AsWideCharString(PyObject *unicode, Py_ssize_t *size)
+{
+    if (fUnicode_AsWideCharString == 0)
+        fUnicode_AsWideCharString = (PyUnicode_AsWideCharStringFn)LOOKUP_SYMBOL(pylib, "PyUnicode_AsWideCharString");
+    return fUnicode_AsWideCharString(unicode, size);
+}
+
+void DPyMem_Free(void *p)
+{
+    if (fMem_Free == 0)
+        fMem_Free = (PyMem_FreeFn)LOOKUP_SYMBOL(pylib, "PyMem_Free");
+    fMem_Free(p);
 }
 
 PyObject* DPy_CompileStringExFlags(const char *str, const char *filename, int start, PyCompilerFlags *flags, int optimize)

--- a/launcher/PythonStubs.h
+++ b/launcher/PythonStubs.h
@@ -66,6 +66,8 @@ int DECLARE_PY(PyType_IsSubtype)(PyTypeObject *a, PyTypeObject *b);
 char* DECLARE_PY(PyUnicode_AsUTF8)(PyObject *unicode);
 PyObject* DECLARE_PY(PyUnicode_DecodeUTF16)(const char *s, Py_ssize_t size, const char *errors, int *byteorder);
 PyObject* DECLARE_PY(PyUnicode_FromString)(const char *u);
+wchar_t *DECLARE_PY(PyUnicode_AsWideCharString)(PyObject *unicode, Py_ssize_t *size);
+void DECLARE_PY(PyMem_Free)(void *p);
 PyObject* DECLARE_PY(Py_CompileStringExFlags)(const char *str, const char *filename, int start, PyCompilerFlags *flags, int optimize);
 void DECLARE_PY(Py_Initialize)();
 void DECLARE_PY(Py_Finalize)();

--- a/launcher/PythonSupport.cpp
+++ b/launcher/PythonSupport.cpp
@@ -1380,3 +1380,14 @@ void _Py_Dealloc(PyObject* o) { (*(Py_TYPE(o)->tp_dealloc))(o); }
 PyAPI_FUNC(void) _Py_Dealloc(PyObject *o) { (*(Py_TYPE(o)->tp_dealloc))(o); }
 #endif
 #endif
+
+PythonWChar::PythonWChar(PyObject *o) : _s(nullptr)
+{
+    _s = CALL_PY(PyUnicode_AsWideCharString)(o, &_size);
+
+}
+
+PythonWChar::~PythonWChar()
+{
+    CALL_PY(PyMem_Free(_s));
+}

--- a/launcher/PythonSupport.cpp
+++ b/launcher/PythonSupport.cpp
@@ -181,10 +181,10 @@ public:
         directories.push_back(fs->absoluteFilePath(home_bin_path, "/usr/local/Cellar/python@" + version));
 
         std::list<std::string> variants;
+        variants.push_back("libpython3.12.dylib");
         variants.push_back("libpython3.11.dylib");
         variants.push_back("libpython3.10.dylib");
         variants.push_back("libpython3.9.dylib");
-        variants.push_back("libpython3.8.dylib");
 
         for (auto directory: directories)
         {
@@ -198,10 +198,10 @@ public:
 
     virtual void buildStandardPaths(FileSystem *fs, const std::string &python_home, std::list<std::string> &filePaths) override
     {
+        filePaths.push_back(fs->absoluteFilePath(python_home, "lib/libpython3.12.dylib"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "lib/libpython3.11.dylib"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "lib/libpython3.10.dylib"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "lib/libpython3.9.dylib"));
-        filePaths.push_back(fs->absoluteFilePath(python_home, "lib/libpython3.8.dylib"));
     }
 
     virtual void buildLibraryPaths(FileSystem *fs, const std::string &python_home, const std::string &python_home_new, std::list<std::string> &filePaths) override
@@ -260,22 +260,22 @@ public:
     virtual void buildVirtualEnvironmentPaths(FileSystem *fs, const std::string &python_home, const std::string &home_bin_path, const std::string &version, std::list<std::string> &filePaths) override
     {
         std::string homeParentDirectory = fs->parentDirectory(home_bin_path);
+        filePaths.push_back(fs->absoluteFilePath(homeParentDirectory, "lib/python3.12/config-3.12-x86_64-linux-gnu/libpython3.12.so"));
         filePaths.push_back(fs->absoluteFilePath(homeParentDirectory, "lib/python3.11/config-3.11-x86_64-linux-gnu/libpython3.11.so"));
         filePaths.push_back(fs->absoluteFilePath(homeParentDirectory, "lib/python3.10/config-3.10-x86_64-linux-gnu/libpython3.10.so"));
         filePaths.push_back(fs->absoluteFilePath(homeParentDirectory, "lib/python3.9/config-3.9-x86_64-linux-gnu/libpython3.9.so"));
-        filePaths.push_back(fs->absoluteFilePath(homeParentDirectory, "lib/python3.8/config-3.8-x86_64-linux-gnu/libpython3.8.so"));
+        filePaths.push_back(fs->absoluteFilePath(homeParentDirectory, "lib/libpython3.12.so"));
         filePaths.push_back(fs->absoluteFilePath(homeParentDirectory, "lib/libpython3.11.so"));
         filePaths.push_back(fs->absoluteFilePath(homeParentDirectory, "lib/libpython3.10.so"));
         filePaths.push_back(fs->absoluteFilePath(homeParentDirectory, "lib/libpython3.9.so"));
-        filePaths.push_back(fs->absoluteFilePath(homeParentDirectory, "lib/libpython3.8.so"));
     }
 
     virtual void buildStandardPaths(FileSystem *fs, const std::string &python_home, std::list<std::string> &filePaths) override
     {
+        filePaths.push_back(fs->absoluteFilePath(python_home, "lib/libpython3.12.so"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "lib/libpython3.11.so"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "lib/libpython3.10.so"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "lib/libpython3.9.so"));
-        filePaths.push_back(fs->absoluteFilePath(python_home, "lib/libpython3.8.so"));
     }
 
     virtual void buildLibraryPaths(FileSystem *fs, const std::string &python_home, const std::string &python_home_new, std::list<std::string> &filePaths) override
@@ -368,38 +368,41 @@ public:
 
     virtual void buildVirtualEnvironmentPaths(FileSystem *fs, const std::string &python_home, const std::string &home_bin_path, const std::string &version, std::list<std::string> &filePaths) override
     {
+        filePaths.push_back(fs->absoluteFilePath(python_home, "Scripts/Python312.dll"));
+        filePaths.push_back(fs->absoluteFilePath(python_home, "Python312.dll"));
+        filePaths.push_back(fs->absoluteFilePath(home_bin_path, "Scripts/Python312.dll"));
+        filePaths.push_back(fs->absoluteFilePath(home_bin_path, "Python312.dll"));
+
         filePaths.push_back(fs->absoluteFilePath(python_home, "Scripts/Python311.dll"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "Python311.dll"));
         filePaths.push_back(fs->absoluteFilePath(home_bin_path, "Scripts/Python311.dll"));
         filePaths.push_back(fs->absoluteFilePath(home_bin_path, "Python311.dll"));
+
         filePaths.push_back(fs->absoluteFilePath(python_home, "Scripts/Python310.dll"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "Python310.dll"));
         filePaths.push_back(fs->absoluteFilePath(home_bin_path, "Scripts/Python310.dll"));
         filePaths.push_back(fs->absoluteFilePath(home_bin_path, "Python310.dll"));
+
         filePaths.push_back(fs->absoluteFilePath(python_home, "Scripts/Python39.dll"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "Python39.dll"));
         filePaths.push_back(fs->absoluteFilePath(home_bin_path, "Scripts/Python39.dll"));
         filePaths.push_back(fs->absoluteFilePath(home_bin_path, "Python39.dll"));
-        filePaths.push_back(fs->absoluteFilePath(python_home, "Scripts/Python38.dll"));
-        filePaths.push_back(fs->absoluteFilePath(python_home, "Python38.dll"));
-        filePaths.push_back(fs->absoluteFilePath(home_bin_path, "Scripts/Python38.dll"));
-        filePaths.push_back(fs->absoluteFilePath(home_bin_path, "Python38.dll"));
     }
 
     virtual void buildStandardPaths(FileSystem *fs, const std::string &python_home, std::list<std::string> &filePaths) override
     {
+        filePaths.push_back(fs->absoluteFilePath(python_home, "Python312.dll"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "Python311.dll"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "Python310.dll"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "Python39.dll"));
-        filePaths.push_back(fs->absoluteFilePath(python_home, "Python38.dll"));
     }
 
     virtual void buildLibraryPaths(FileSystem *fs, const std::string &python_home, const std::string &python_home_new, std::list<std::string> &filePaths) override
     {
+        filePaths.push_back(fs->absoluteFilePath(python_home, "Scripts/python312.zip"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "Scripts/python311.zip"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "Scripts/python310.zip"));
         filePaths.push_back(fs->absoluteFilePath(python_home, "Scripts/python39.zip"));
-        filePaths.push_back(fs->absoluteFilePath(python_home, "Scripts/python38.zip"));
         filePaths.push_back(fs->absoluteFilePath(python_home_new, "DLLs"));
         filePaths.push_back(fs->absoluteFilePath(python_home_new, "lib"));
         filePaths.push_back(python_home_new);

--- a/launcher/PythonSupport.h
+++ b/launcher/PythonSupport.h
@@ -118,6 +118,19 @@ struct PythonValueVariant {
 PythonValueVariant PyObjectToValueVariant(PyObject *py_object);
 PyObject *PythonValueVariantToPyObject(const PythonValueVariant &value_variant);
 
+class PythonWChar
+{
+    wchar_t *_s;
+    Py_ssize_t _size;
+
+public:
+    PythonWChar(PyObject *o);
+    ~PythonWChar();
+
+    wchar_t *s() const { return _s; }
+    Py_ssize_t size() const { return _size; }
+};
+
 class ImageInterface;
 
 typedef PyObject *CreateAndAddModuleFn();

--- a/setup.py
+++ b/setup.py
@@ -117,21 +117,21 @@ dest_drop = None
 
 if sys.platform == "darwin":
     platform = "macosx_10_11_intel" if platform_module.processor() != "arm" else "macosx_11_0_arm64"
-    python_version = "cp39.cp310.cp311"
+    python_version = "cp39.cp310.cp311.cp312"
     abi = "abi3"
     dest = "bin"
     dir_path = "launcher/build/Release"
     dest_drop = 3
 if sys.platform == "win32":
     platform = "win_amd64"
-    python_version = "cp39.cp310.cp311"
+    python_version = "cp39.cp310.cp311.cp312"
     abi = "none"
     dest = f"Scripts/{launcher}"
     dir_path = "launcher/x64/Release"
     dest_drop = 3
 if sys.platform == "linux":
     platform = "manylinux1_x86_64"
-    python_version = "cp39.cp310.cp311"
+    python_version = "cp39.cp310.cp311.cp312"
     abi = "abi3"
     dest = f"bin/{launcher}"
     dir_path = "launcher/linux/x64"


### PR DESCRIPTION
- Use PyUnicode_AsWideCharString on PyObject instead of deprecated direct unicode.
- Add Python 3.12 DLL support.
