### PR TITLE
Add numpy 2 requirement to avoid installing with older nionui.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,10 @@ setuptools.setup(
     data_files=data_files,
     distclass=BinaryDistribution,
     cmdclass={'bdist_wheel': bdist_wheel},
+    install_requires=
+    [
+        'numpy >=2.0,<3.0'
+    ],
     classifiers=[
         'License :: OSI Approved :: Apache Software License',
     ],


### PR DESCRIPTION
While not strictly necessary, and this version is explicitly _not_ dependent
on numpy, adding this requirement will prevent this version from being used
with older nionui. This is necessary because the API has changed
(DrawingContext_paintRGBAToImage, etc.).
