### PR TITLE
Fix several canvas item thread shutdown race conditions.

### DIFF
--- a/launcher/DocumentWindow.h
+++ b/launcher/DocumentWindow.h
@@ -648,6 +648,7 @@ public:
     void continuePaintingSection(const RenderResult &render_result);
 
 private:
+    bool m_closing;
     QVariant m_py_object;
     QMutex m_sections_mutex;
     QMap<int, CanvasSectionSharedPtr> m_sections;


### PR DESCRIPTION
@Tiomat85 This has been merged to address crash issues in the field. Please consider reviewing anyway for follow-up releases.